### PR TITLE
Fix typo in to_dict function

### DIFF
--- a/rmapy/api.py
+++ b/rmapy/api.py
@@ -115,7 +115,7 @@ class Client(object):
             "deviceID": uuid,
 
         }
-        response = self.request("POST", DEVICE_TOKEN_URL, body)
+        response = self.request("POST", DEVICE_TOKEN_URL, body=body)
         if response.ok:
             self.token_set["devicetoken"] = response.text
             dump(self.token_set)

--- a/rmapy/meta.py
+++ b/rmapy/meta.py
@@ -56,7 +56,7 @@ class Meta(object):
             "ID": self.ID,
             "Version": self.Version,
             "Message": self.Message,
-            "Succes": self.Success,
+            "Success": self.Success,
             "BlobURLGet": self.BlobURLGet,
             "BlobURLGetExpires": self.BlobURLGetExpires,
             "BlobURLPut": self.BlobURLPut,


### PR DESCRIPTION
To resolve bug at import-time:

```python
  File ".../python3.7/site-packages/rmapy/meta.py", line 44, in __init__
    setattr(self, k, kwargs.get(k, getattr(self, k)))
AttributeError: 'Folder' object has no attribute 'Succes'
```